### PR TITLE
make Python 3 compatible by using unicode strings

### DIFF
--- a/src/parse_metadata.py
+++ b/src/parse_metadata.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 import os
+import sys
 import subprocess
 import struct
 
@@ -9,14 +10,14 @@ logger = logging.getLogger('vvzen.parse_metadata')
 
 
 class EXR_ATTRIBUTES:
-    COMPRESSION_VALUES = ('NO_COMPRESSION', 'RLE_COMPRESSION',
-                          'ZIPS_COMPRESSION', 'ZIP_COMPRESSION',
-                          'PIZ_COMPRESSION', 'PXR24_COMPRESSION',
-                          'B44_COMPRESSION', 'B44A_COMPRESSION')
+    COMPRESSION_VALUES = (u'NO_COMPRESSION', u'RLE_COMPRESSION',
+                          u'ZIPS_COMPRESSION', u'ZIP_COMPRESSION',
+                          u'PIZ_COMPRESSION', u'PXR24_COMPRESSION',
+                          u'B44_COMPRESSION', u'B44A_COMPRESSION')
 
-    LINE_ORDER = ('INCREASING_Y', 'DECREASING_Y', 'RANDOM_Y')
+    LINE_ORDER = (u'INCREASING_Y', u'DECREASING_Y', u'RANDOM_Y')
 
-    ENVMAP_TYPES = ('ENVMAP_LATLONG', 'ENVMAP_CUBE')
+    ENVMAP_TYPES = (u'ENVMAP_LATLONG', u'ENVMAP_CUBE')
 
 
 def read_until_null(filebuffer, maxbytes=1024):
@@ -32,21 +33,28 @@ def read_until_null(filebuffer, maxbytes=1024):
         int: how many bytes were read
     """
 
-    current_string = ''
+    current_string = b''
     current_byte = filebuffer.read(1)
     bytes_read = 1
 
-    while current_byte != '\x00':
+    while current_byte != b'\x00':
 
         current_string += current_byte
-        # print 'current byte: {}'.format(current_byte)
+        # print('current byte: {}'.format(current_byte))
 
         bytes_read += 1
         current_byte = struct.unpack('c', filebuffer.read(1))[0]
 
         if bytes_read > maxbytes:
-            print 'exiting due to infinite loop'
+            print('exiting due to infinite loop')
             break
+
+    # for python3 make sure to encode bytes to unicode string
+    if sys.version_info.major == 2:
+        current_string = unicode(current_string, encoding='utf8')
+    else:
+        current_string = str(current_string, encoding='utf8')
+
 
     return current_string, bytes_read
 
@@ -107,36 +115,36 @@ def read_exr_header(exrpath, maxreadsize=2000):
             if not attribute_name in metadata:
                 metadata[attribute_name] = {}
 
-            # print 'attribute name: {}, length: {}, type: {}, size: {}'.format(
+            # print('attribute name: {}, length: {}, type: {}, size: {}'.format(
             #     attribute_name, attribute_name_length, attribute_type,
-            #     attribute_size)
+            #     attribute_size))
 
             # How many bytes of the attribute value we've read
             byte_count = 0
 
             # Parse the attribute value
 
-            if attribute_type == 'box2i':
+            if attribute_type == u'box2i':
                 box_values = struct.unpack('i' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
-                    'xMin': box_values[0],
-                    'yMin': box_values[1],
-                    'xMax': box_values[2],
-                    'yMax': box_values[3]
+                    u'xMin': box_values[0],
+                    u'yMin': box_values[1],
+                    u'xMax': box_values[2],
+                    u'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'box2f':
+            elif attribute_type == u'box2f':
                 box_values = struct.unpack('f' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
-                    'xMin': box_values[0],
-                    'yMin': box_values[1],
-                    'xMax': box_values[2],
-                    'yMax': box_values[3]
+                    u'xMin': box_values[0],
+                    u'yMin': box_values[1],
+                    u'xMax': box_values[2],
+                    u'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'chlist':
+            elif attribute_type == u'chlist':
 
                 channel_data = {}
 
@@ -146,8 +154,8 @@ def read_exr_header(exrpath, maxreadsize=2000):
                         exr_file)
 
                     byte_count += channel_name_length
-                    # print 'read {} bytes of {}'.format(byte_count,
-                    #                                    attribute_size)
+                    # print('read {} bytes of {}'.format(byte_count,
+                    #                                    attribute_size))
 
                     # If we've read only one byte it means it was a null char
                     # We've found the end of the channels attribute
@@ -166,89 +174,89 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     byte_count += 4
 
                     channel_data[channel_name] = {
-                        'pixel_type': pixel_type,
-                        'pLinear': p_linear,
-                        'reserved': [ord(c) for c in reserved],
-                        'xSampling': x_sampling,
-                        'ySampling': y_sampling
+                        u'pixel_type': pixel_type,
+                        u'pLinear': p_linear,
+                        u'reserved': [ord(c) for c in reserved],
+                        u'xSampling': x_sampling,
+                        u'ySampling': y_sampling
                     }
 
                     metadata[attribute_name] = channel_data
 
-            elif attribute_type == 'chromaticities':
+            elif attribute_type == u'chromaticities':
                 chromaticities = struct.unpack('f' * 8, exr_file.read(4 * 8))
                 metadata[attribute_name] = {
-                    'redX': chromaticities[0],
-                    'redY': chromaticities[1],
-                    'greenX': chromaticities[2],
-                    'greenY': chromaticities[3],
-                    'blueX': chromaticities[4],
-                    'blueY': chromaticities[5],
-                    'whiteX': chromaticities[6],
-                    'whiteY': chromaticities[7],
+                    u'redX': chromaticities[0],
+                    u'redY': chromaticities[1],
+                    u'greenX': chromaticities[2],
+                    u'greenY': chromaticities[3],
+                    u'blueX': chromaticities[4],
+                    u'blueY': chromaticities[5],
+                    u'whiteX': chromaticities[6],
+                    u'whiteY': chromaticities[7],
                 }
 
-            elif attribute_type == 'compression':
+            elif attribute_type == u'compression':
                 compression_value = struct.unpack('B', exr_file.read(1))
                 compression_value = int(compression_value[0])
 
                 try:
-                    metadata['compression'] = EXR_ATTRIBUTES.COMPRESSION_VALUES[
+                    metadata[u'compression'] = EXR_ATTRIBUTES.COMPRESSION_VALUES[
                         compression_value]
 
                 except IndexError:
-                    metadata['compression'] = 'unknown'
+                    metadata[u'compression'] = u'unknown'
 
-            elif attribute_type == 'double':
+            elif attribute_type == u'double':
                 attribute_value = struct.unpack('d', exr_file.read(8 * 1))
                 metadata[attribute_name] = attribute_value[0]
 
-            elif attribute_type == 'envmap':
+            elif attribute_type == u'envmap':
                 attribute_value = struct.unpack('B', exr_file.read(1 * 1))
 
                 try:
                     metadata[attribute_name] = EXR_ATTRIBUTES.ENVMAP_TYPES[
                         attribute_value[0]]
                 except IndexError:
-                    metadata[attribute_name] = 'unknown'
+                    metadata[attribute_name] = u'unknown'
 
-            elif attribute_type == 'float':
+            elif attribute_type == u'float':
                 float_value = struct.unpack('f', exr_file.read(4))
                 metadata[attribute_name] = float_value[0]
 
-            elif attribute_type == 'int':
+            elif attribute_type == u'int':
                 attribute_value = int(
                     struct.unpack('i', exr_file.read(4 * 1))[0])
 
                 metadata[attribute_name] = attribute_value
 
-            elif attribute_type == 'keycode':
+            elif attribute_type == u'keycode':
                 attribute_values = struct.unpack('i' * 7, exr_file.read(4 * 7))
 
                 metadata[attribute_name] = {
-                    'filmMfcCode': attribute_values[0],
-                    'filmType': attribute_values[1],
-                    'prefix': attribute_values[2],
-                    'count': attribute_values[3],
-                    'perfOffset': attribute_values[4],
-                    'perfsPerFrame': attribute_values[5],
-                    'perfsPerCount': attribute_values[6]
+                    u'filmMfcCode': attribute_values[0],
+                    u'filmType': attribute_values[1],
+                    u'prefix': attribute_values[2],
+                    u'count': attribute_values[3],
+                    u'perfOffset': attribute_values[4],
+                    u'perfsPerFrame': attribute_values[5],
+                    u'perfsPerCount': attribute_values[6]
                 }
 
-            elif attribute_type == 'lineOrder':
+            elif attribute_type == u'lineOrder':
                 line_order = int(struct.unpack('B', exr_file.read(1))[0])
                 metadata[attribute_name] = EXR_ATTRIBUTES.LINE_ORDER[line_order]
 
-            elif attribute_type == 'm33f':
+            elif attribute_type == u'm33f':
                 attribute_values = struct.unpack('f' * 9, exr_file.read(4 * 9))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'm44f':
+            elif attribute_type == u'm44f':
                 attribute_values = struct.unpack('f' * 16,
                                                  exr_file.read(4 * 16))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'preview':
+            elif attribute_type == u'preview':
 
                 width = struct.unpack('I', exr_file.read(4 * 1))
                 height = struct.unpack('I', exr_file.read(4 * 1))
@@ -257,27 +265,27 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'B', exr_file.read(1 * 4 * width * height))
 
                 metadata[attribute_name] = {
-                    'width': width,
-                    'height': height,
-                    'pixel_data': pixel_data
+                    u'width': width,
+                    u'height': height,
+                    u'pixel_data': pixel_data
                 }
 
-            elif attribute_type == 'rational':
+            elif attribute_type == u'rational':
                 first_part = struct.unpack('i', exr_file.read(4))
                 second_part = struct.unpack('I', exr_file.read(4))
                 metadata[attribute_name] = {
-                    'first_num': first_part[0],
-                    'second_num': second_part[0]
+                    u'first_num': first_part[0],
+                    u'second_num': second_part[0]
                 }
 
-            elif attribute_type == 'string':
+            elif attribute_type == u'string':
 
                 string_content = struct.unpack('c' * attribute_size,
                                                exr_file.read(attribute_size))
 
                 metadata[attribute_name] = ''.join(string_content)
 
-            elif attribute_type == 'stringvector':
+            elif attribute_type == u'stringvector':
                 metadata[attribute_name] = []
 
                 while byte_count < attribute_size:
@@ -289,46 +297,46 @@ def read_exr_header(exrpath, maxreadsize=2000):
                                                    exr_file.read(string_length))
                     byte_count += string_length
 
-                    # print 'string length: {}'.format(string_length)
-                    # print 'string content: {}'.format(string_content)
+                    # print('string length: {}'.format(string_length))
+                    # print('string content: {}'.format(string_content))
 
                     metadata[attribute_name].append(''.join(string_content))
 
-            elif attribute_type == 'tiledesc':
+            elif attribute_type == u'tiledesc':
                 x_size = struct.unpack('I', exr_file.read(4 * 1))
                 y_size = struct.unpack('I', exr_file.read(4 * 1))
                 mode = struct.unpack('B', exr_file.read(1 * 1))
 
                 metadata[attribute_name] = {
-                    'xSize': x_size,
-                    'ySize': y_size,
-                    'mode': mode
+                    u'xSize': x_size,
+                    u'ySize': y_size,
+                    u'mode': mode
                 }
 
-            elif attribute_type == 'timecode':
+            elif attribute_type == u'timecode':
                 time_and_flags = struct.unpack('I', exr_file.read(4 * 1))
                 user_data = struct.unpack('I', exr_file.read(4 * 1))
 
                 metadata[attribute_name] = {
-                    'timeAndFlags': time_and_flags,
-                    'userData': user_data
+                    u'timeAndFlags': time_and_flags,
+                    u'userData': user_data
                 }
 
-            elif attribute_type == 'v2i':
+            elif attribute_type == u'v2i':
                 vector_2d_value = struct.unpack('ii', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v2f':
+            elif attribute_type == u'v2f':
                 vector_2d_value = struct.unpack('ff', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v3i':
+            elif attribute_type == u'v3i':
                 vector_3d_value = struct.unpack('iii', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -336,7 +344,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 metadata[attribute_name].append(vector_3d_value[1])
                 metadata[attribute_name].append(vector_3d_value[2])
 
-            elif attribute_type == 'v3f':
+            elif attribute_type == u'v3f':
                 vector_3d_value = struct.unpack('fff', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -348,7 +356,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 logger.error(
                     'unknown attribute type: {}!!'.format(attribute_type))
 
-                metadata[attribute_name] = 'unknown attribute type!'
+                metadata[attribute_name] = u'unknown attribute type!'
 
                 raise TypeError(
                     'unknown attribute type: {}'.format(attribute_type))


### PR DESCRIPTION
make Python 3 compatible by using unicode strings
Script is now working in Python 2 and 3.

All bytes strings get converted to unicode string to be future prove and conform with Python 3 strings.
Please be aware that this could cause issues with Python 2 for comparison of bytes strings and unicode string of your current code.

- fix print for python 3
- convert strings to unicode strings
- in read_until_null make sure to use bytes string until the end of function, here convert to unicode string