### PR TITLE
add Python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,20 @@ If you only need to do something as trivial as reading the metadata of an EXR fi
 That's why I've written this very small python module (currently ~360 LOCs) that simply reads the header of an exr file, according to the official EXR documentation available here: https://www.openexr.com/documentation/openexrfilelayout.pdf
 
 # Dependencies
+Optional, for tests:
 pytest==4.2.0
+
+# Install
+This script is not packaged in any fancy way. Just grab the `parse_metadata.py` and put it wherever you want.
+Maybe in the future I'll add a small cli and package everything properly.
 
 # Tests
 I'm not a TDD guy (yet) - so there are very few tests. I'm planning to write more of them as soon as I can breathe a little.
 You can run tests by typing: `pytest` from the root dir of this repo.
+
+You will need also the git submodule that contains all the exr images, so you need to clone the repo like this:
+
+`git clone --recurse-submodules git@github.com:vvzen/parse-exr-header.git`
 
 # PR & Bugs
 Fill free to submit Pull Requests if you notice anything wrong. I'm more than happy to merge them and adapt them to my coding style (which is just PEP8 stuff with some additional things like lowercase functions args in order to distinguish arguments from variables inside the scope of a function - very useful in my opinion and blog post coming soon).

--- a/src/parse_metadata.py
+++ b/src/parse_metadata.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 import os
+import sys
 import subprocess
 import struct
 
@@ -32,23 +33,35 @@ def read_until_null(filebuffer, maxbytes=1024):
         int: how many bytes were read
     """
 
-    current_string = ''
+    current_string = b''
     current_byte = filebuffer.read(1)
     bytes_read = 1
 
-    while current_byte != '\x00':
+    while current_byte != b'\x00':
 
         current_string += current_byte
-        # print 'current byte: {}'.format(current_byte)
+        # print('current byte: {}'.format(current_byte))
 
         bytes_read += 1
         current_byte = struct.unpack('c', filebuffer.read(1))[0]
 
         if bytes_read > maxbytes:
-            print 'exiting due to infinite loop'
+            print('exiting due to infinite loop')
             break
 
     return current_string, bytes_read
+
+
+def convert_to_unicode_string(data):
+    """Recursively convert dictionary keys and values to unicode strings"""
+    if isinstance(data, dict):
+        return {convert_to_unicode_string(k): convert_to_unicode_string(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [convert_to_unicode_string(v) for v in data]
+    elif isinstance(data, bytes):
+        return str(data, encoding='utf-8')
+    else:
+        return data
 
 
 def read_exr_header(exrpath, maxreadsize=2000):
@@ -107,16 +120,16 @@ def read_exr_header(exrpath, maxreadsize=2000):
             if not attribute_name in metadata:
                 metadata[attribute_name] = {}
 
-            # print 'attribute name: {}, length: {}, type: {}, size: {}'.format(
+            # print('attribute name: {}, length: {}, type: {}, size: {}'.format(
             #     attribute_name, attribute_name_length, attribute_type,
-            #     attribute_size)
+            #     attribute_size))
 
             # How many bytes of the attribute value we've read
             byte_count = 0
 
             # Parse the attribute value
 
-            if attribute_type == 'box2i':
+            if attribute_type == b'box2i':
                 box_values = struct.unpack('i' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
@@ -126,7 +139,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'box2f':
+            elif attribute_type == b'box2f':
                 box_values = struct.unpack('f' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
@@ -136,7 +149,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'chlist':
+            elif attribute_type == b'chlist':
 
                 channel_data = {}
 
@@ -146,8 +159,8 @@ def read_exr_header(exrpath, maxreadsize=2000):
                         exr_file)
 
                     byte_count += channel_name_length
-                    # print 'read {} bytes of {}'.format(byte_count,
-                    #                                    attribute_size)
+                    # print('read {} bytes of {}'.format(byte_count,
+                    #                                    attribute_size))
 
                     # If we've read only one byte it means it was a null char
                     # We've found the end of the channels attribute
@@ -175,7 +188,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
 
                     metadata[attribute_name] = channel_data
 
-            elif attribute_type == 'chromaticities':
+            elif attribute_type == b'chromaticities':
                 chromaticities = struct.unpack('f' * 8, exr_file.read(4 * 8))
                 metadata[attribute_name] = {
                     'redX': chromaticities[0],
@@ -188,7 +201,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'whiteY': chromaticities[7],
                 }
 
-            elif attribute_type == 'compression':
+            elif attribute_type == b'compression':
                 compression_value = struct.unpack('B', exr_file.read(1))
                 compression_value = int(compression_value[0])
 
@@ -199,11 +212,11 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 except IndexError:
                     metadata['compression'] = 'unknown'
 
-            elif attribute_type == 'double':
+            elif attribute_type == b'double':
                 attribute_value = struct.unpack('d', exr_file.read(8 * 1))
                 metadata[attribute_name] = attribute_value[0]
 
-            elif attribute_type == 'envmap':
+            elif attribute_type == b'envmap':
                 attribute_value = struct.unpack('B', exr_file.read(1 * 1))
 
                 try:
@@ -212,17 +225,17 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 except IndexError:
                     metadata[attribute_name] = 'unknown'
 
-            elif attribute_type == 'float':
+            elif attribute_type == b'float':
                 float_value = struct.unpack('f', exr_file.read(4))
                 metadata[attribute_name] = float_value[0]
 
-            elif attribute_type == 'int':
+            elif attribute_type == b'int':
                 attribute_value = int(
                     struct.unpack('i', exr_file.read(4 * 1))[0])
 
                 metadata[attribute_name] = attribute_value
 
-            elif attribute_type == 'keycode':
+            elif attribute_type == b'keycode':
                 attribute_values = struct.unpack('i' * 7, exr_file.read(4 * 7))
 
                 metadata[attribute_name] = {
@@ -235,20 +248,20 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'perfsPerCount': attribute_values[6]
                 }
 
-            elif attribute_type == 'lineOrder':
+            elif attribute_type == b'lineOrder':
                 line_order = int(struct.unpack('B', exr_file.read(1))[0])
                 metadata[attribute_name] = EXR_ATTRIBUTES.LINE_ORDER[line_order]
 
-            elif attribute_type == 'm33f':
+            elif attribute_type == b'm33f':
                 attribute_values = struct.unpack('f' * 9, exr_file.read(4 * 9))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'm44f':
+            elif attribute_type == b'm44f':
                 attribute_values = struct.unpack('f' * 16,
                                                  exr_file.read(4 * 16))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'preview':
+            elif attribute_type == b'preview':
 
                 width = struct.unpack('I', exr_file.read(4 * 1))
                 height = struct.unpack('I', exr_file.read(4 * 1))
@@ -262,7 +275,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'pixel_data': pixel_data
                 }
 
-            elif attribute_type == 'rational':
+            elif attribute_type == b'rational':
                 first_part = struct.unpack('i', exr_file.read(4))
                 second_part = struct.unpack('I', exr_file.read(4))
                 metadata[attribute_name] = {
@@ -270,14 +283,14 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'second_num': second_part[0]
                 }
 
-            elif attribute_type == 'string':
+            elif attribute_type == b'string':
 
                 string_content = struct.unpack('c' * attribute_size,
                                                exr_file.read(attribute_size))
 
-                metadata[attribute_name] = ''.join(string_content)
+                metadata[attribute_name] = b''.join(string_content)
 
-            elif attribute_type == 'stringvector':
+            elif attribute_type == b'stringvector':
                 metadata[attribute_name] = []
 
                 while byte_count < attribute_size:
@@ -289,12 +302,12 @@ def read_exr_header(exrpath, maxreadsize=2000):
                                                    exr_file.read(string_length))
                     byte_count += string_length
 
-                    # print 'string length: {}'.format(string_length)
-                    # print 'string content: {}'.format(string_content)
+                    # print('string length: {}'.format(string_length))
+                    # print('string content: {}'.format(string_content))
 
-                    metadata[attribute_name].append(''.join(string_content))
+                    metadata[attribute_name].append(b''.join(string_content))
 
-            elif attribute_type == 'tiledesc':
+            elif attribute_type == b'tiledesc':
                 x_size = struct.unpack('I', exr_file.read(4 * 1))
                 y_size = struct.unpack('I', exr_file.read(4 * 1))
                 mode = struct.unpack('B', exr_file.read(1 * 1))
@@ -305,7 +318,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'mode': mode
                 }
 
-            elif attribute_type == 'timecode':
+            elif attribute_type == b'timecode':
                 time_and_flags = struct.unpack('I', exr_file.read(4 * 1))
                 user_data = struct.unpack('I', exr_file.read(4 * 1))
 
@@ -314,21 +327,21 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'userData': user_data
                 }
 
-            elif attribute_type == 'v2i':
+            elif attribute_type == b'v2i':
                 vector_2d_value = struct.unpack('ii', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v2f':
+            elif attribute_type == b'v2f':
                 vector_2d_value = struct.unpack('ff', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v3i':
+            elif attribute_type == b'v3i':
                 vector_3d_value = struct.unpack('iii', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -336,7 +349,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 metadata[attribute_name].append(vector_3d_value[1])
                 metadata[attribute_name].append(vector_3d_value[2])
 
-            elif attribute_type == 'v3f':
+            elif attribute_type == b'v3f':
                 vector_3d_value = struct.unpack('fff', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -358,4 +371,9 @@ def read_exr_header(exrpath, maxreadsize=2000):
     finally:
         exr_file.close()
 
-    return metadata
+    if sys.version_info.major == 2:
+        # for Python 2 each string in the result should be a byte string
+        return metadata
+    else:
+        # for Python 3 make sure to encode all byte string to unicode string
+        return convert_to_unicode_string(metadata)

--- a/src/parse_metadata.py
+++ b/src/parse_metadata.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 import os
+import sys
 import subprocess
 import struct
 
@@ -32,23 +33,35 @@ def read_until_null(filebuffer, maxbytes=1024):
         int: how many bytes were read
     """
 
-    current_string = ''
+    current_string = b''
     current_byte = filebuffer.read(1)
     bytes_read = 1
 
-    while current_byte != '\x00':
+    while current_byte != b'\x00':
 
         current_string += current_byte
-        # print 'current byte: {}'.format(current_byte)
+        # print('current byte: {}'.format(current_byte))
 
         bytes_read += 1
         current_byte = struct.unpack('c', filebuffer.read(1))[0]
 
         if bytes_read > maxbytes:
-            print 'exiting due to infinite loop'
+            print('exiting due to infinite loop')
             break
 
     return current_string, bytes_read
+
+
+def convert_to_unicode_string(data):
+    """Recursively convert dictionary keys and values to unicode strings"""
+    if isinstance(data, dict):
+        return {convert_to_unicode_string(k): convert_to_unicode_string(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [convert_to_unicode_string(v) for v in data]
+    elif isinstance(data, bytes):
+        return str(data, encoding='utf-8')
+    else:
+        return data
 
 
 def read_exr_header(exrpath, maxreadsize=2000):
@@ -107,16 +120,16 @@ def read_exr_header(exrpath, maxreadsize=2000):
             if not attribute_name in metadata:
                 metadata[attribute_name] = {}
 
-            # print 'attribute name: {}, length: {}, type: {}, size: {}'.format(
+            # print('attribute name: {}, length: {}, type: {}, size: {}'.format(
             #     attribute_name, attribute_name_length, attribute_type,
-            #     attribute_size)
+            #     attribute_size))
 
             # How many bytes of the attribute value we've read
             byte_count = 0
 
             # Parse the attribute value
 
-            if attribute_type == 'box2i':
+            if attribute_type == b'box2i':
                 box_values = struct.unpack('i' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
@@ -126,7 +139,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'box2f':
+            elif attribute_type == b'box2f':
                 box_values = struct.unpack('f' * 4, exr_file.read(4 * 4))
 
                 metadata[attribute_name] = {
@@ -136,7 +149,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'yMax': box_values[3]
                 }
 
-            elif attribute_type == 'chlist':
+            elif attribute_type == b'chlist':
 
                 channel_data = {}
 
@@ -146,8 +159,8 @@ def read_exr_header(exrpath, maxreadsize=2000):
                         exr_file)
 
                     byte_count += channel_name_length
-                    # print 'read {} bytes of {}'.format(byte_count,
-                    #                                    attribute_size)
+                    # print('read {} bytes of {}'.format(byte_count,
+                    #                                    attribute_size))
 
                     # If we've read only one byte it means it was a null char
                     # We've found the end of the channels attribute
@@ -175,7 +188,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
 
                     metadata[attribute_name] = channel_data
 
-            elif attribute_type == 'chromaticities':
+            elif attribute_type == b'chromaticities':
                 chromaticities = struct.unpack('f' * 8, exr_file.read(4 * 8))
                 metadata[attribute_name] = {
                     'redX': chromaticities[0],
@@ -188,7 +201,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'whiteY': chromaticities[7],
                 }
 
-            elif attribute_type == 'compression':
+            elif attribute_type == b'compression':
                 compression_value = struct.unpack('B', exr_file.read(1))
                 compression_value = int(compression_value[0])
 
@@ -199,11 +212,11 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 except IndexError:
                     metadata['compression'] = 'unknown'
 
-            elif attribute_type == 'double':
+            elif attribute_type == b'double':
                 attribute_value = struct.unpack('d', exr_file.read(8 * 1))
                 metadata[attribute_name] = attribute_value[0]
 
-            elif attribute_type == 'envmap':
+            elif attribute_type == b'envmap':
                 attribute_value = struct.unpack('B', exr_file.read(1 * 1))
 
                 try:
@@ -212,17 +225,17 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 except IndexError:
                     metadata[attribute_name] = 'unknown'
 
-            elif attribute_type == 'float':
+            elif attribute_type == b'float':
                 float_value = struct.unpack('f', exr_file.read(4))
                 metadata[attribute_name] = float_value[0]
 
-            elif attribute_type == 'int':
+            elif attribute_type == b'int':
                 attribute_value = int(
                     struct.unpack('i', exr_file.read(4 * 1))[0])
 
                 metadata[attribute_name] = attribute_value
 
-            elif attribute_type == 'keycode':
+            elif attribute_type == b'keycode':
                 attribute_values = struct.unpack('i' * 7, exr_file.read(4 * 7))
 
                 metadata[attribute_name] = {
@@ -235,20 +248,20 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'perfsPerCount': attribute_values[6]
                 }
 
-            elif attribute_type == 'lineOrder':
+            elif attribute_type == b'lineOrder':
                 line_order = int(struct.unpack('B', exr_file.read(1))[0])
                 metadata[attribute_name] = EXR_ATTRIBUTES.LINE_ORDER[line_order]
 
-            elif attribute_type == 'm33f':
+            elif attribute_type == b'm33f':
                 attribute_values = struct.unpack('f' * 9, exr_file.read(4 * 9))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'm44f':
+            elif attribute_type == b'm44f':
                 attribute_values = struct.unpack('f' * 16,
                                                  exr_file.read(4 * 16))
                 metadata[attribute_name] = attribute_values
 
-            elif attribute_type == 'preview':
+            elif attribute_type == b'preview':
 
                 width = struct.unpack('I', exr_file.read(4 * 1))
                 height = struct.unpack('I', exr_file.read(4 * 1))
@@ -262,7 +275,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'pixel_data': pixel_data
                 }
 
-            elif attribute_type == 'rational':
+            elif attribute_type == b'rational':
                 first_part = struct.unpack('i', exr_file.read(4))
                 second_part = struct.unpack('I', exr_file.read(4))
                 metadata[attribute_name] = {
@@ -270,14 +283,14 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'second_num': second_part[0]
                 }
 
-            elif attribute_type == 'string':
+            elif attribute_type == b'string':
 
                 string_content = struct.unpack('c' * attribute_size,
                                                exr_file.read(attribute_size))
 
                 metadata[attribute_name] = ''.join(string_content)
 
-            elif attribute_type == 'stringvector':
+            elif attribute_type == b'stringvector':
                 metadata[attribute_name] = []
 
                 while byte_count < attribute_size:
@@ -289,12 +302,12 @@ def read_exr_header(exrpath, maxreadsize=2000):
                                                    exr_file.read(string_length))
                     byte_count += string_length
 
-                    # print 'string length: {}'.format(string_length)
-                    # print 'string content: {}'.format(string_content)
+                    # print('string length: {}'.format(string_length))
+                    # print('string content: {}'.format(string_content))
 
                     metadata[attribute_name].append(''.join(string_content))
 
-            elif attribute_type == 'tiledesc':
+            elif attribute_type == b'tiledesc':
                 x_size = struct.unpack('I', exr_file.read(4 * 1))
                 y_size = struct.unpack('I', exr_file.read(4 * 1))
                 mode = struct.unpack('B', exr_file.read(1 * 1))
@@ -305,7 +318,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'mode': mode
                 }
 
-            elif attribute_type == 'timecode':
+            elif attribute_type == b'timecode':
                 time_and_flags = struct.unpack('I', exr_file.read(4 * 1))
                 user_data = struct.unpack('I', exr_file.read(4 * 1))
 
@@ -314,21 +327,21 @@ def read_exr_header(exrpath, maxreadsize=2000):
                     'userData': user_data
                 }
 
-            elif attribute_type == 'v2i':
+            elif attribute_type == b'v2i':
                 vector_2d_value = struct.unpack('ii', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v2f':
+            elif attribute_type == b'v2f':
                 vector_2d_value = struct.unpack('ff', exr_file.read(4 * 2))
 
                 metadata[attribute_name] = []
                 metadata[attribute_name].append(vector_2d_value[0])
                 metadata[attribute_name].append(vector_2d_value[1])
 
-            elif attribute_type == 'v3i':
+            elif attribute_type == b'v3i':
                 vector_3d_value = struct.unpack('iii', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -336,7 +349,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 metadata[attribute_name].append(vector_3d_value[1])
                 metadata[attribute_name].append(vector_3d_value[2])
 
-            elif attribute_type == 'v3f':
+            elif attribute_type == b'v3f':
                 vector_3d_value = struct.unpack('fff', exr_file.read(4 * 3))
 
                 metadata[attribute_name] = []
@@ -358,4 +371,9 @@ def read_exr_header(exrpath, maxreadsize=2000):
     finally:
         exr_file.close()
 
-    return metadata
+    if sys.version_info.major == 2:
+        # for Python 2 each string in the result should be a byte string
+        return metadata
+    else:
+        # for Python 3 make sure to encode all byte string to unicode string
+        return convert_to_unicode_string(metadata)

--- a/tests/test_exr.py
+++ b/tests/test_exr.py
@@ -3,6 +3,18 @@ import pytest
 import sys
 import os
 
+"""
+The tests work with Python 2 and Python 3.
+Please remember that Python 2 works with byte strings as default
+and with the change of Python 3 unicode strings are used.
+
+Python 2 default string
+foo = b'bar'
+
+Python 3 default string:
+foo = u'bar'
+"""
+
 # Append the required module
 # Not the best way but it works in Python 2.7
 sys.path.append(
@@ -45,3 +57,51 @@ class TestEXRParsing:
 
         metadata = parse_metadata.read_exr_header(self.rec709_test_image_path)
         assert metadata['owner'] == 'Copyright 2006 Industrial Light & Magic'
+
+    def test_exr_meta_all(self):
+        expected = {
+            'compression': 'PIZ_COMPRESSION',
+            'pixelAspectRatio': 1.0,
+            'displayWindow': {
+                'xMin': 0,
+                'yMin': 0,
+                'yMax': 405,
+                'xMax': 609
+            },
+            'channels': {
+                'R': {
+                    'reserved': [0, 0, 0],
+                    'pLinear': (0, ),
+                    'pixel_type': (1, ),
+                    'xSampling': (1, ),
+                    'ySampling': (1, )
+                },
+                'B': {
+                    'reserved': [0, 0, 0],
+                    'pLinear': (0, ),
+                    'pixel_type': (1, ),
+                    'xSampling': (1, ),
+                    'ySampling': (1, )
+                },
+                'G': {
+                    'reserved': [0, 0, 0],
+                    'pLinear': (0, ),
+                    'pixel_type': (1, ),
+                    'xSampling': (1, ),
+                    'ySampling': (1, )
+                }
+            },
+            'dataWindow': {
+                'xMin': 0,
+                'yMin': 0,
+                'yMax': 405,
+                'xMax': 609
+            },
+            'screenWindowCenter': [0.0, 0.0],
+            'owner': 'Copyright 2006 Industrial Light & Magic',
+            'screenWindowWidth': 1.0,
+            'lineOrder': 'INCREASING_Y'
+        }
+
+        result = parse_metadata.read_exr_header(self.rec709_test_image_path)
+        assert result == expected


### PR DESCRIPTION
Script is now working in Python 2 and 3.
For Python 2: nothing changes.
For Python 3: all bytes strings get converted to unicode string to be future prove and conform with Python 3 strings.