### PR TITLE
support for returning combined channel list of multi-part files

### DIFF
--- a/tests/test_exr.py
+++ b/tests/test_exr.py
@@ -104,6 +104,116 @@ def test_exr_meta_owner():
         'owner': 'Copyright 2006 Industrial Light & Magic',
         'screenWindowWidth': 1.0,
         'lineOrder': 'INCREASING_Y'
+    }),
+    # Beachball (multipart)
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'Beachball', 'multipart.0001.exr'), {
+        'compression': 'ZIPS_COMPRESSION',
+        'pixelAspectRatio': 1.0,
+        'displayWindow': {
+            'xMax': 2047,
+            'xMin': 0,
+            'yMax': 1555,
+            'yMin': 0
+        },
+        'dataWindow': {
+            'xMax': 1530,
+            'xMin': 654,
+            'yMax': 1120,
+            'yMin': 245
+        },
+        'channels': {
+            'A': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'B': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'G': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'R': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'Z': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'disparityL.x': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'disparityL.y': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'disparityR.x': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'disparityR.y': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'forward.u': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'forward.v': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            },
+            'whitebarmask.mask': {
+                'pLinear': 0,
+                'pixel_type': 1,
+                'reserved': [0, 0, 0],
+                'xSampling': 1,
+                'ySampling': 1
+            }
+        },
+        'screenWindowCenter': [0.0, 0.0],
+        'screenWindowWidth': 1.0,
+        'lineOrder': 'INCREASING_Y',
+        'chunkCount': 876,
+        'name': 'rgba_right',
+        'type': 'scanlineimage',
+        'view': 'right',
     })
 ])
 def test_exr_meta_all(input_path, expected_metadata):


### PR DESCRIPTION
Currently, read_exr_header() will only read the first header of a multi-part OpenEXR file which results in an incomplete channel list. This patch adds a mechanism to read all headers separated by null bytes if the exr's flags indicate that a multi-part file is being processed. The returned dict will contain a "channels" attribute that is a combination of all channels across all the parts.

This isn't full multi-part support since according to the OpenEXR standard, the same attribute may have different values in different parts of the file (the part's "name" attribute being the most obvious one). But supporting this would require much more profound changes to the returned dict.
