### PR TITLE
Feature/add cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Optional, for formatting:
 `yapf==0.30.0`
 
 # Support
+
+## Python version
 This repo now supports both Python2.7 and also Python3.8.
 Thanks to [jonaskluger](https://github.com/jonaskluger) for providing python3 support.
+
+## Multipart files
+Support for multipart files is on its way but it will need a bit of work since the original design of this hobby project was a bit naive. A PR is currently pending.
 
 # Install
 This script is not packaged in any fancy way. Just grab the `parse_metadata.py` and put it wherever you want.
@@ -39,7 +44,7 @@ Fill free to submit Pull Requests if you notice anything wrong. I'm more than ha
 ### Formatting
 I use [yapf](https://github.com/google/yapf) to end all style wars and let it do all of the formatting for me. After you made a PR, you can run it like this:
 ```
-yapf --in-place src/parse_metadata.py
+yapf --in-place src/*.py
 ```
 
 This of course requires you to have `yapf` installed locally or somewhere in your `$PATH`.

--- a/src/bin/vv-exr-metadata.py
+++ b/src/bin/vv-exr-metadata.py
@@ -26,14 +26,17 @@ def main():
                         help="Path to source exr image")
 
     args = parser.parse_args()
+    paths = args.source_paths
 
-    for path in args.source_paths:
+    for path in paths:
         if not os.path.exists(path):
             log.error("Source Path was not found on disk: %s", path)
             continue
 
         metadata = parse_metadata.read_exr_header(path)
         print(pprint.pformat(metadata))
+        if len(paths) > 1:
+            print("-"*80)
 
 if __name__ == '__main__':
     main()

--- a/src/bin/vv-exr-metadata.py
+++ b/src/bin/vv-exr-metadata.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import os
+import sys
+import pprint
+import logging
+import argparse
+
+log = logging.getLogger('vvzen.parse_metadata')
+log.setLevel(logging.INFO)
+console_handler = logging.StreamHandler()
+log.addHandler(console_handler)
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.append(os.path.join(CURRENT_DIR, ".."))
+import parse_metadata
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(type=str,
+                        nargs="+",
+                        dest="source_paths",
+                        help="Path to source exr image")
+
+    args = parser.parse_args()
+
+    for path in args.source_paths:
+        if not os.path.exists(path):
+            log.error("Source Path was not found on disk: %s", path)
+            continue
+
+        metadata = parse_metadata.read_exr_header(path)
+        print(pprint.pformat(metadata))
+
+if __name__ == '__main__':
+    main()

--- a/src/parse_metadata.py
+++ b/src/parse_metadata.py
@@ -1,12 +1,10 @@
 #-*- coding: utf-8 -*-
 import os
 import sys
-import subprocess
 import struct
-
 import logging
 
-logger = logging.getLogger('vvzen.parse_metadata')
+log = logging.getLogger('vvzen.parse_metadata')
 
 
 class EXR_ATTRIBUTES:
@@ -73,7 +71,9 @@ def read_exr_header(exrpath, maxreadsize=2000):
 
     Args:
         exrpath (str): absolute path to the exr file
-        maxreadsize (int, optional): Avoids infinite loops in case a final null byte is never encountered or the exr is formatted in a bad way. Defaults to 2000.
+        maxreadsize (int, optional): Avoids infinite loops in case a final null
+            byte is never encountered or the exr is formatted in a bad way.
+            Defaults to 2000.
 
     Raises:
         OSError: if the exr does not exist
@@ -93,23 +93,22 @@ def read_exr_header(exrpath, maxreadsize=2000):
     try:
 
         magic_number = struct.unpack('i', exr_file.read(4))
-        logger.info('magic_number: {}'.format(magic_number[0]))
-
         openxr_version_number = struct.unpack('c', exr_file.read(1))
-        logger.info('OpenEXR Version Number: {}'.format(
-            ord(openxr_version_number[0])))
-
         version_field_attrs = struct.unpack('ccc', exr_file.read(3))
-        logger.info('version_field_attrs : {} {} {}'.format(
-            ord(version_field_attrs[0]), ord(version_field_attrs[1]),
-            ord(version_field_attrs[2])))
 
+        log.info("READING: '%s'.\n\tMagic number: %i.\n\t"
+                 "OpenEXR Version Number: %i.\n\tVersion field: %s %s %s",
+                 os.path.basename(exrpath), magic_number[0],
+                 ord(openxr_version_number[0]),
+                 ord(version_field_attrs[0]), ord(version_field_attrs[1]),
+                 ord(version_field_attrs[2]))
+        log.info("METADATA:")
         i = 0
 
         while i < maxreadsize:
 
-            # We'll always have attribute name, attribute type separated by a null byte
-            # Then attribute size and attribute value follow
+            # We'll always have attribute name, attribute type separated by a
+            # null byte. Then attribute size and attribute value follow
             attribute_name, attribute_name_length = read_until_null(exr_file)
             attribute_type, _ = read_until_null(exr_file)
             attribute_size = int(struct.unpack('i', exr_file.read(4))[0])
@@ -117,21 +116,16 @@ def read_exr_header(exrpath, maxreadsize=2000):
             # If we're reading only byte it means it's the null byte
             # and we've reached the end of the header
             if attribute_name_length == 1:
-                logger.info('reached the end of the header!')
+                log.debug('reached the end of the header!')
                 break
 
             if not attribute_name in metadata:
                 metadata[attribute_name] = {}
 
-            # print('attribute name: {}, length: {}, type: {}, size: {}'.format(
-            #     attribute_name, attribute_name_length, attribute_type,
-            #     attribute_size))
-
             # How many bytes of the attribute value we've read
             byte_count = 0
 
             # Parse the attribute value
-
             if attribute_type == b'box2i':
                 box_values = struct.unpack('i' * 4, exr_file.read(4 * 4))
 
@@ -273,8 +267,8 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 # preview_size should equal attribute_size-8
                 preview_size = 1 * 4 * width * height
 
-                pixel_data = struct.unpack(
-                    '%dB' % preview_size, exr_file.read(preview_size))
+                pixel_data = struct.unpack('%dB' % preview_size,
+                                           exr_file.read(preview_size))
 
                 metadata[attribute_name] = {
                     'width': width,
@@ -365,8 +359,7 @@ def read_exr_header(exrpath, maxreadsize=2000):
                 metadata[attribute_name].append(vector_3d_value[2])
 
             else:
-                logger.error(
-                    'unknown attribute type: {}!!'.format(attribute_type))
+                log.error('unknown attribute type: %s!!', attribute_type)
 
                 metadata[attribute_name] = 'unknown attribute type!'
 

--- a/src/parse_metadata.py
+++ b/src/parse_metadata.py
@@ -91,13 +91,12 @@ def read_exr_header(exrpath, maxreadsize=2000):
     metadata = {}
 
     try:
-
         magic_number = struct.unpack('i', exr_file.read(4))
         openxr_version_number = struct.unpack('c', exr_file.read(1))
         version_field_attrs = struct.unpack('ccc', exr_file.read(3))
 
-        log.info("READING: '%s'.\n\tMagic number: %i.\n\t"
-                 "OpenEXR Version Number: %i.\n\tVersion field: %s %s %s",
+        log.info("File name: '%s'\nMagic number: %i\n"
+                 "OpenEXR Version Number: %i\nVersion field: %s %s %s",
                  os.path.basename(exrpath), magic_number[0],
                  ord(openxr_version_number[0]),
                  ord(version_field_attrs[0]), ord(version_field_attrs[1]),

--- a/tests/test_exr.py
+++ b/tests/test_exr.py
@@ -1,10 +1,11 @@
 #-*- coding: utf-8 -*-
-import pytest
-import sys
 import os
+import sys
+
+import pytest
 
 """
-The tests work with Python 2 and Python 3.
+The tests are ment to work with Python 2 and Python 3.
 Please remember that Python 2 works with byte strings as default
 and with the change of Python 3 unicode strings are used.
 
@@ -16,7 +17,6 @@ foo = u'bar'
 """
 
 # Append the required module
-# Not the best way but it works in Python 2.7
 sys.path.append(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'src'))
 
@@ -26,82 +26,86 @@ EXR_IMAGES_DIR_PATH = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'openexr-images')
 
 
-class TestEXRParsing:
+REC709_TEST_IMAGE_PATH = os.path.join(EXR_IMAGES_DIR_PATH,
+                                      'Chromaticities', 'Rec709.exr')
 
-    rec709_test_image_path = os.path.join(EXR_IMAGES_DIR_PATH, 'Chromaticities',
-                                          'Rec709.exr')
+def test_oserror_thrown_if_file_does_not_exist():
+    with pytest.raises(OSError):
+        parse_metadata.read_exr_header('pippo.exr')
 
-    def test_oserror_thrown_if_file_does_not_exist(self):
+@pytest.mark.parametrize("input_path,expected_lineorder", [
+    pytest.param(REC709_TEST_IMAGE_PATH, 'INCREASING_Y')
+])
+def test_exr_meta_lineOrder(input_path, expected_lineorder):
+    metadata = parse_metadata.read_exr_header(input_path)
+    assert metadata['lineOrder'] == expected_lineorder
 
-        exr_path = 'pippo.exr'
+@pytest.mark.parametrize("input_path,expected_compression", [
+    pytest.param(REC709_TEST_IMAGE_PATH, 'PIZ_COMPRESSION'),
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'Chromaticities', 'XYZ.exr'), 'PIZ_COMPRESSION'),
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'Chromaticities', 'XYZ_YC.exr'), 'PIZ_COMPRESSION'),
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'TestImages', 'GammaChart.exr'), 'PXR24_COMPRESSION'),
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'TestImages', 'BrightRings.exr'), 'ZIP_COMPRESSION'),
+    pytest.param(os.path.join(EXR_IMAGES_DIR_PATH, 'TestImages', 'SquaresSwirls.exr'), 'PXR24_COMPRESSION'),
+])
+def test_exr_meta_compression(input_path,expected_compression):
+    metadata = parse_metadata.read_exr_header(input_path)
+    assert metadata['compression'] == expected_compression
 
-        with pytest.raises(OSError):
-            parse_metadata.read_exr_header(exr_path)
+def test_exr_meta_pixelAspectRatio():
+    metadata = parse_metadata.read_exr_header(REC709_TEST_IMAGE_PATH)
+    assert metadata['pixelAspectRatio'] == 1
 
-    def test_exr_meta_lineOrder(self):
+def test_exr_meta_owner():
+    metadata = parse_metadata.read_exr_header(REC709_TEST_IMAGE_PATH)
+    assert metadata['owner'] == 'Copyright 2006 Industrial Light & Magic'
 
-        metadata = parse_metadata.read_exr_header(self.rec709_test_image_path)
-        assert metadata['lineOrder'] == 'INCREASING_Y'
-
-    def test_exr_meta_compression(self):
-
-        metadata = parse_metadata.read_exr_header(self.rec709_test_image_path)
-        assert metadata['compression'] == 'PIZ_COMPRESSION'
-
-    def test_exr_meta_pixelAspectRatio(self):
-
-        metadata = parse_metadata.read_exr_header(self.rec709_test_image_path)
-        assert metadata['pixelAspectRatio'] == 1
-
-    def test_exr_meta_owner(self):
-
-        metadata = parse_metadata.read_exr_header(self.rec709_test_image_path)
-        assert metadata['owner'] == 'Copyright 2006 Industrial Light & Magic'
-
-    def test_exr_meta_all(self):
-        expected = {
-            'compression': 'PIZ_COMPRESSION',
-            'pixelAspectRatio': 1.0,
-            'displayWindow': {
-                'xMin': 0,
-                'yMin': 0,
-                'yMax': 405,
-                'xMax': 609
+@pytest.mark.parametrize("input_path,expected_metadata", [
+    # Rec709.exr
+    pytest.param(REC709_TEST_IMAGE_PATH, {
+        'compression': 'PIZ_COMPRESSION',
+        'pixelAspectRatio': 1.0,
+        'displayWindow': {
+            'xMin': 0,
+            'yMin': 0,
+            'yMax': 405,
+            'xMax': 609
+        },
+        'channels': {
+            'R': {
+                'reserved': [0, 0, 0],
+                'pLinear': 0,
+                'pixel_type': 1,
+                'xSampling': 1,
+                'ySampling': 1
             },
-            'channels': {
-                'R': {
-                    'reserved': [0, 0, 0],
-                    'pLinear': 0,
-                    'pixel_type': 1,
-                    'xSampling': 1,
-                    'ySampling': 1
-                },
-                'B': {
-                    'reserved': [0, 0, 0],
-                    'pLinear': 0,
-                    'pixel_type': 1,
-                    'xSampling': 1,
-                    'ySampling': 1
-                },
-                'G': {
-                    'reserved': [0, 0, 0],
-                    'pLinear': 0,
-                    'pixel_type': 1,
-                    'xSampling': 1,
-                    'ySampling': 1
-                }
+            'B': {
+                'reserved': [0, 0, 0],
+                'pLinear': 0,
+                'pixel_type': 1,
+                'xSampling': 1,
+                'ySampling': 1
             },
-            'dataWindow': {
-                'xMin': 0,
-                'yMin': 0,
-                'yMax': 405,
-                'xMax': 609
-            },
-            'screenWindowCenter': [0.0, 0.0],
-            'owner': 'Copyright 2006 Industrial Light & Magic',
-            'screenWindowWidth': 1.0,
-            'lineOrder': 'INCREASING_Y'
-        }
-
-        result = parse_metadata.read_exr_header(self.rec709_test_image_path)
-        assert result == expected
+            'G': {
+                'reserved': [0, 0, 0],
+                'pLinear': 0,
+                'pixel_type': 1,
+                'xSampling': 1,
+                'ySampling': 1
+            }
+        },
+        'dataWindow': {
+            'xMin': 0,
+            'yMin': 0,
+            'yMax': 405,
+            'xMax': 609
+        },
+        'screenWindowCenter': [0.0, 0.0],
+        'owner': 'Copyright 2006 Industrial Light & Magic',
+        'screenWindowWidth': 1.0,
+        'lineOrder': 'INCREASING_Y'
+    })
+])
+def test_exr_meta_all(input_path, expected_metadata):
+    result = parse_metadata.read_exr_header(input_path)
+    assert result == expected_metadata


### PR DESCRIPTION
This PR adds a small cli (`bin/vv-exr-metadata.py`) that can be used to print the metadata to stdout from a terminal session. The aim of the cli is to make it easy to programmatically `grep` the correct information.